### PR TITLE
Allow users to register/login via Facebook Auth

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -3,6 +3,6 @@
 const { router } = require('./router');
 const { localStrategy, jwtStrategy } = require('./strategies/local');
 const { facebookStrategy } = require('./strategies/facebook');
-const { googleStrategy } = require('./strategies/google')
+const { googleStrategy } = require('./strategies/google');
 
 module.exports = { router, localStrategy, jwtStrategy, facebookStrategy, googleStrategy };

--- a/auth/router.js
+++ b/auth/router.js
@@ -66,7 +66,11 @@ router.post('/facebook', (req, res) => {
                   'facebook.id': user_id,
                   'facebook.token': userToken
                 })
-                  .then(user => console.log(user));
+                  .then(user => {
+                    console.log('User create', user.apiRepr());
+                    const authToken = createAuthToken(user.apiRepr());
+                    return res.status(201).location(`/api/auth/${user.id}`).json({authToken});
+                  });
               }
               if(user) {
                 user.email ? user.facebook.id = user_id : user.email = userData.email;

--- a/auth/router.js
+++ b/auth/router.js
@@ -50,10 +50,10 @@ router.post('/facebook', (req, res) => {
         .then(userData => {
           // console.log('User data', userData)
           // User.find({'facebook.id': user_id} || {'email': userData.email})
-          User.findOne({'email': userData.email})
+          User.findOne({$or: [{'email': userData.email}, {'facebook.id': user_id}]})
             .then(_user => {
               user = _user;
-              console.log('user after query', user)
+              console.log('user after query', user);
               if (!user) {
                 const { first_name, last_name, email } = userData;
                 let name = {
@@ -71,13 +71,17 @@ router.post('/facebook', (req, res) => {
               if(user) {
                 user.email ? user.facebook.id = user_id : user.email = userData.email;
                 user.facebook.token = userToken;
-                console.log('user after assigning keys', user)
+                console.log('user after assigning keys', user);
               }
+              return user.save();      
+            })
+            .then(user => {
+              const authToken = createAuthToken(user.apiRepr());
+              console.log('user api repr', user.apiRepr());
+              console.log('our auth token', authToken);
+              return res.json({authToken}); 
             });
-          
         });
-      const authToken = createAuthToken(req.user.apiRepr());
-      res.json({authToken});
     });
 });
 

--- a/auth/router.js
+++ b/auth/router.js
@@ -32,12 +32,7 @@ router.post('/refresh', jwtAuth, (req, res) => {
   res.json({authToken});
 });
 
-//1.check to see if email matches an existing user, if it does, save the facebook information in that user's profile, return the auth token to the client
-//2.check to see if facebook_id matches existing id, return auth token to client
-//3.if no local user exists, create one, return auth token to client
-//4. save fb token to facebook.token
 router.post('/facebook', (req, res) => {
-  //check to see if token is valid
   let user;
   const userToken = req.body.token;
   console.log('user token', userToken);
@@ -48,8 +43,6 @@ router.post('/facebook', (req, res) => {
       fetch(`https://graph.facebook.com/${user_id}?access_token=${FACEBOOK_APP_TOKEN}&fields=id,first_name,last_name,email`)
         .then(response => response.json())
         .then(userData => {
-          // console.log('User data', userData)
-          // User.find({'facebook.id': user_id} || {'email': userData.email})
           User.findOne({$or: [{'email': userData.email}, {'facebook.id': user_id}]})
             .then(_user => {
               user = _user;

--- a/auth/router.js
+++ b/auth/router.js
@@ -2,8 +2,9 @@
 const express = require('express');
 const passport = require('passport');
 const bodyParser = require('body-parser');
+const fetch = require('node-fetch');
 const jwt = require('jsonwebtoken');
-const { JWT_SECRET, JWT_EXPIRY } = require('../config');
+const { JWT_SECRET, JWT_EXPIRY, FACEBOOK_APP_TOKEN } = require('../config');
 const router = express.Router();
 
 router.use(bodyParser.json());
@@ -30,18 +31,13 @@ router.post('/refresh', jwtAuth, (req, res) => {
   res.json({authToken});
 });
 
-router.get('/facebook', passport.authenticate('facebook'));
-//the callback is where we store user details and redirect users
-router.get('/facebook/callback', passport.authenticate('facebook', {
-  session: false,
-  failureRedirect: '/login'
-}), (req, res) => {
-  res.redirect('/');
-  console.log('req.user in fb callback', req.user);
-  // res.json({
-  //   token: req.user.accessToken
-  // });
-}
-);
+router.post('/facebook', (req, res) => {
+  //check to see if token is valid
+  const userToken = req.body.token;
+  fetch(`https://graph.facebook.com/debug_token?input_token=${userToken}&access_token=${FACEBOOK_APP_TOKEN}`)
+    .then(response => response.json())
+    .then(data => console.log(data));
+  res.json(req.body);
+});
 
 module.exports = { router };

--- a/auth/router.js
+++ b/auth/router.js
@@ -35,28 +35,44 @@ router.post('/refresh', jwtAuth, (req, res) => {
 router.post('/facebook', (req, res) => {
   //check to see if token is valid
   const userToken = req.body.token;
+  console.log('user token', userToken);
   fetch(`https://graph.facebook.com/debug_token?input_token=${userToken}&access_token=${FACEBOOK_APP_TOKEN}`)
     .then(response => response.json())
     .then(data => {
-      const { user_id } = data;
-      console.log(user_id);
-      User.findOne({'facebook.id': user_id}, function(err, user) {
-        if (err) {
-          return err;
-        }
-        if (user) {
-          const authToken = createAuthToken(user.apiRepr());
-          res.json({authToken});
-        } else {
-          //need to query the profile for name and email, save the fb token to the db
-          fetch(`https://graph.facebook.com/${user_id}`)
-            .then(response => response.json())
-            .then(data => console.log(data));
-
-        } 
-      });
-
+      // console.log('Data', data.data)
+      const { user_id } = data.data;
+      console.log('User id', user_id);
+      fetch(`https://graph.facebook.com/${user_id}?access_token=${FACEBOOK_APP_TOKEN}&fields=id,first_name,last_name,email`)
+        .then(response => response.json())
+        .then(userData => console.log('User data', userData));
     });
+  res.send('ok');
+  // console.log(user_id);
+  // let user;
+  // return User.findOne({'facebook.id': user_id})
+  //   .then(_user => {
+  //     user = _user;
+  //     if(!user) {
+  //       User.create({
+  //         name,
+  //         email
+  //       });
+  //     }
+  //     .then(user => {
+  //       const authToken = createAuthToken(user.apiRepr());
+  //       return res.status(201).json({authToken})
+  //     })
+
+
+  //need to query the profile for name and email, save the fb token to the db
+  // fetch(`https://graph.facebook.com/${user_id}`)
+  //   .then(response => response.json())
+  //   .then(data => console.log(data));
+        
+
+        
+    
+
   //check to see if fb id exists for a user in our database
   //if the user doesnt exist create the users
   //create the auth token and send back the auth token

--- a/config.js
+++ b/config.js
@@ -4,12 +4,13 @@ module.exports = {
   PORT: process.env.PORT || 8080,
   CLIENT_ORIGIN: process.env.CLIENT_ORIGIN || 'http://localhost:3000',
   DATABASE_URL:
-        process.env.DATABASE_URL || 'mongodb://localhost/newsapp-backend',
+        process.env.DATABASE_URL || 'mongodb://cohort16:th1nkful@ds143678.mlab.com:43678/news-app-capstone',
   TEST_DATABASE_URL:
         process.env.TEST_DATABASE_URL ||
         'mongodb://localhost/newsapp-backend-test',
   FACEBOOK_APP_ID: 1989958031254651,
   FACEBOOK_APP_SECRET: process.env.FACEBOOK_APP_SECRET,
+  FACEBOOK_APP_TOKEN: process.env.FACEBOOK_APP_TOKEN,
   GOOGLE_CLIENT_ID: '1013252237653-a8qenljcndk5fm41nifn7oetaaglr6k3.apps.googleusercontent.com',
   GOOGLE_CLIENT_SECRET: process.env.GOOGLE_APP_SECRET,
   JWT_SECRET: process.env.JWT_SECRET,
@@ -20,3 +21,4 @@ module.exports = {
   //     process.env.TEST_DATABASE_URL ||
   //     'postgres://localhost/thinkful-backend-test'
 };
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -3744,6 +3744,11 @@
         "request": "2.83.0"
       }
     },
+    "node-fetch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.0.0.tgz",
+      "integrity": "sha1-mCu6Q+zU8pIqKcwYamu7C7c/y6Y="
+    },
     "nodemon": {
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.15.1.tgz",
@@ -5784,6 +5789,11 @@
         "wrappy": "1.0.2"
       }
     },
+    "openid": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/openid/-/openid-0.5.13.tgz",
+      "integrity": "sha1-G462yox67m3WJktp2vua14UsKk0="
+    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -5854,6 +5864,15 @@
         "passport-oauth2": "1.4.0"
       }
     },
+    "passport-google": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/passport-google/-/passport-google-0.3.0.tgz",
+      "integrity": "sha1-xbS0FiZYiSs3Flt5WgH/1Mfhn7c=",
+      "requires": {
+        "passport-openid": "0.3.1",
+        "pkginfo": "0.2.3"
+      }
+    },
     "passport-jwt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-3.0.1.tgz",
@@ -5894,6 +5913,27 @@
         "passport-strategy": "1.0.0",
         "uid2": "0.0.3",
         "utils-merge": "1.0.0"
+      }
+    },
+    "passport-openid": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/passport-openid/-/passport-openid-0.3.1.tgz",
+      "integrity": "sha1-5k3gSFn6UbZSlIAXQSJiHgj6Iss=",
+      "requires": {
+        "openid": "0.5.13",
+        "passport": "0.1.18",
+        "pkginfo": "0.2.3"
+      },
+      "dependencies": {
+        "passport": {
+          "version": "0.1.18",
+          "resolved": "https://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
+          "integrity": "sha1-yCZEedy2QUytu2Z1LRKzfgtlJaE=",
+          "requires": {
+            "pause": "0.0.1",
+            "pkginfo": "0.2.3"
+          }
+        }
       }
     },
     "passport-strategy": {
@@ -6039,6 +6079,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
+    },
+    "pkginfo": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "mongoose": "^5.0.6",
     "morgan": "^1.9.0",
     "newsapi": "^2.2.0",
+    "node-fetch": "^2.0.0",
     "passport": "^0.4.0",
     "passport-facebook": "^2.1.1",
     "passport-google": "^0.3.0",


### PR DESCRIPTION
Users who click the 'connect with Facebook' link on the frontend are able to authenticate via OAuth and register/login to the app. Users are saved to the database with their email, first and last name received from Facebook. If a user was authenticated with our local auth and they decide to 'connect with Facebook', we save their Facebook profile ID and access token in their user record.